### PR TITLE
Update Main.hs

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -128,7 +128,7 @@ showMisoIndent _ (MisoText txt) = "text \"" ++ txt ++ "\""
 showMisoIndent indent (MisoElement name attrs elems) =
   name ++ "_ " ++ line ++ showAttrs attrs ++ line ++
   case elems of
-    [] -> ""
+    [] -> "[]"
     m@(MisoText _) : rest -> "[ " ++ showMisoIndent indent m ++ " ]" ++ listIndent (map (showMisoIndent (indent + indent)) rest)
     _ -> "[ " ++ listIndent (map (showMisoIndent (indent + indent)) elems) ++ line ++ "]"
   where


### PR DESCRIPTION
In cases where no child elements exist, `[]` is omitted. We should keep an empty list instead, even if no children are specified. (e.g. <i></i>, should be `i_ [] []`, not just `i_ []`)
before
```html
fn3 = nav_ 
  [ class_ "level is-mobile" ]
  [ div_ 
    [ class_ "level-left" ]
    [ a_ 
        [ class_ "level-item" ]
        [ span_ 
                [ class_ "icon is-small" ]
                [ i_ 
                                [ class_ "fa fa-reply" ]
                ]
        ]
```
after
```
fn3 = nav_ 
  [ class_ "level is-mobile" ]
  [ div_ 
    [ class_ "level-left" ]
    [ a_ 
        [ class_ "level-item" ]
        [ span_ 
                [ class_ "icon is-small" ]
                [ i_ 
                                [ class_ "fa fa-reply" ]
                                []
                ]
        ]
```